### PR TITLE
Refactored and added optional path separator

### DIFF
--- a/dictor/__init__.py
+++ b/dictor/__init__.py
@@ -1,11 +1,10 @@
-
 #!/usr/bin/env python
 # coding=utf-8
 
 from __future__ import print_function
 import json
 
-def dictor(data, path=None, default=None, checknone=False, ignorecase=False):
+def dictor(data, path=None, default=None, checknone=False, ignorecase=False, pathsep="."):
     '''
     Usage:
     get a value from a Dictionary key
@@ -42,14 +41,8 @@ def dictor(data, path=None, default=None, checknone=False, ignorecase=False):
     if r'\.' in path:
         path = path.replace(r'\.', '__dictor__')
 
-    keys = path.split(".")
-
-    if ignorecase:
-        data = {k.lower():v for k,v in data.items()}
-
-    for i in range(len(keys)):
-        key = keys[i]
-        try:
+    try:
+        for key in path.split(pathsep):
             if key.isdigit():
                 if type(data) is list:
                     val = data[int(key)]
@@ -57,24 +50,19 @@ def dictor(data, path=None, default=None, checknone=False, ignorecase=False):
                     val = data[key]
             else:
                 if ignorecase:
-                    key = key.lower()
+                    for datakey in data.keys():
+                        if datakey.lower() == key.lower():
+                             key = datakey
+                             break
 
                 if '__dictor__' in key:
                     key = key.replace('__dictor__', '.')
 
-                try:
-                    val = data[key]
-                except (KeyError, ValueError, IndexError, TypeError):
-                    if checknone:
-                        val = False
-                        break
-                    val = default
-                    break
-
+                val = data[key]
             data = val
-        except (KeyError, ValueError, IndexError, TypeError):
-            val = default
-                
+    except (KeyError, ValueError, IndexError, TypeError):
+        val = default
+            
     if checknone:
         if not val or val == default:
             raise ValueError('value not found for search path: "%s"' % path)        

--- a/dictor/__init__.py
+++ b/dictor/__init__.py
@@ -35,28 +35,18 @@ def dictor(data, path=None, default=None, checknone=False, ignorecase=False, pat
     '''
 
     if path is None or path == '':
-        return json.dumps(data)
-
-    # handle keys with dots in them
-    if r'\.' in path:
-        path = path.replace(r'\.', '__dictor__')
+        return data
 
     try:
         for key in path.split(pathsep):
-            if key.isdigit():
-                if type(data) is list:
-                    val = data[int(key)]
-                else:
-                    val = data[key]
+            if isinstance(data, (list, tuple)):
+                val = data[int(key)]
             else:
                 if ignorecase:
                     for datakey in data.keys():
                         if datakey.lower() == key.lower():
                              key = datakey
                              break
-
-                if '__dictor__' in key:
-                    key = key.replace('__dictor__', '.')
 
                 val = data[key]
             data = val

--- a/tests/test.py
+++ b/tests/test.py
@@ -56,6 +56,11 @@ def test_complex_dict():
     result = dictor(BASIC, 'terminator.1.terminator 2.genre.0')
     eq_('nuclear war', result)
 
+def test_pathsep():
+    ''' test parsing down a list and getting dict value '''
+    result = dictor(BASIC, 'terminator/1/terminator 2/genre/0', pathsep='/')
+    eq_('nuclear war', result)
+
 def test_keys_with_dots():
     ''' test parsing keys with dots in them '''
     result = dictor(BASIC, 'dirty\.harry.genre')
@@ -64,6 +69,11 @@ def test_keys_with_dots():
 def test_ignore_letter_casing():
     ''' test ignoring letter upper/lower case '''
     result = dictor(BASIC, 'austin PoWeRs.year', ignorecase=True)
+    eq_(1996, result)
+    
+def test_ignore_letter_casing_nested():
+    ''' test ignoring letter upper/lower case '''
+    result = dictor(BASIC, 'austin PoWeRs.Year', ignorecase=True)
     eq_(1996, result)
     
 def test_numeric_key_handling():

--- a/tests/test.py
+++ b/tests/test.py
@@ -63,7 +63,7 @@ def test_pathsep():
 
 def test_keys_with_dots():
     ''' test parsing keys with dots in them '''
-    result = dictor(BASIC, 'dirty\.harry.genre')
+    result = dictor(BASIC, 'dirty.harry/genre', pathsep="/")
     eq_('romance', result)
 
 def test_ignore_letter_casing():


### PR DESCRIPTION
Allow user to use something other than "." as path separator.  So look for keys with "/" or any character.

Moved the entire loop in one enclosing try block instead of one try block per iteration.