### PR TITLE
Fix the problem with installation in Windows 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ if the entire JSON structure is a list
 
 just provide the list index into search path
 
-    print(dictor(data, ‘2.color’))
+    print(dictor(data, '2.color'))
 
     >> blue
 


### PR DESCRIPTION
In windows 10 while installing dictor you have an error  UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 4391: character maps to <undefined>. Happens because of using non standart quotes and cp1251 encoding couldn't handle it.
Quotes changed to '